### PR TITLE
https://github.com/KeepSafe/Switchboard/issues/6

### DIFF
--- a/client/ios/SwitchboardSample/SwitchboardSample/Switchboard/Switchboard.m
+++ b/client/ios/SwitchboardSample/SwitchboardSample/Switchboard/Switchboard.m
@@ -263,7 +263,11 @@ static Switchboard *sharedInstance = nil;
     [params setObject:uuid forKey:@"uuid"];
     [params setObject:device forKey:@"device"];
     [params setObject:language forKey:@"lang"];
-    [params setObject:country forKey:@"country"];
+    
+    if (country != nil) {
+        [params setObject:country forKey:@"country"];
+    }
+    
     [params setObject:manufacturer forKey:@"manufacturer"];
     [params setObject:packageName forKey:@"appId"];
     [params setObject:versionName forKey:@"version"];


### PR DESCRIPTION
Check country has a value before setting it to prevent crash if Apple didn't set a country for the device at ship time.
